### PR TITLE
Feature/create turn class and tests

### DIFF
--- a/src/Turn.js
+++ b/src/Turn.js
@@ -1,0 +1,24 @@
+class Turn {
+  constructor(guess, currentCard) {
+    this.guess = guess;
+    this.currentCard = currentCard;
+  }
+
+  returnGuess() {
+    return this.guess;
+  }
+
+  returnCard() {
+    return this.currentCard;
+  }
+
+  evaluateGuess() {
+    return (this.guess === this.currentCard.correctAnswer) ? true : false;
+  }
+
+  giveFeedback() {
+    return (this.evaluateGuess()) ? "Correct!" : "Incorrect!";
+  }
+}
+
+module.exports = Turn;

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -25,6 +25,11 @@ describe('Card', function() {
     expect(card.answers).to.deep.equal(['object', 'array', 'function']);
   });
 
+  it('should store the correct answer', function() {
+    const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
+    expect(card.correctAnswer).to.equal('object');
+  });
+
   it('should store a card ID', function() {
     const card = new Card(1, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
     expect(card.cardId).to.equal(1);

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -17,7 +17,7 @@ describe('Card', function() {
 
   it('should store a question', function() {
     const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-    expect(card.question).to.equal('What allows you to define a set of related information using key-value pairs?');
+    expect(card.question).to.deep.equal('What allows you to define a set of related information using key-value pairs?');
   });
 
   it('should store a list of possible answers', function() {
@@ -27,22 +27,22 @@ describe('Card', function() {
 
   it('should store the correct answer', function() {
     const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-    expect(card.correctAnswer).to.equal('object');
+    expect(card.correctAnswer).to.deep.equal('object');
   });
 
   it('should store a card ID', function() {
     const card = new Card(1, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.cardId).to.equal(1);
+    expect(card.cardId).to.deep.equal(1);
   });
 
   it('should store a different id', function() {
     const card = new Card(2, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.cardId).to.equal(2);
+    expect(card.cardId).to.deep.equal(2);
   });
 
   it('should store a different question', function() {
     const card = new Card(2, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.question).to.equal('What is a comma-separated list of related values?');
+    expect(card.question).to.deep.equal('What is a comma-separated list of related values?');
   });
 
   it('should store a different set of possible answers', function() {
@@ -52,6 +52,6 @@ describe('Card', function() {
 
   it('should store a different correct answer', function() {
     const card = new Card(2, 'What is a comma-separated list of related values?', ["mutator method", "accessor method", "iteration method"], 'array');
-    expect(card.correctAnswer).to.equal('array');
+    expect(card.correctAnswer).to.deep.equal('array');
   });
 });

--- a/test/Turn-test.js
+++ b/test/Turn-test.js
@@ -1,0 +1,75 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Turn = require('../src/Turn');
+const Card = require('../src/Card');
+
+describe('Turn', function() {
+
+  it('should be a function', function() {
+    const turn = new Turn();
+    expect(Turn).to.be.a('function');
+  });
+
+  it('should be an instance of Turn', function() {
+    const turn = new Turn();
+    expect(turn).to.be.an.instanceof(Turn);
+  });
+
+  it('should only accept a string answer from a user', function() {
+    const turn = new Turn('boo');
+    const newTurn = new Turn('woo');
+
+    expect(turn.guess).to.equal('boo');
+    expect(turn.guess).to.be.a.string('boo');
+
+    expect(newTurn.guess).to.equal('woo');
+    expect(newTurn.guess).to.be.a.string('woo');
+  });
+
+  it('should play the current card', function() {
+    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    const turn = new Turn('boo', card);
+
+    expect(turn.currentCard).to.deep.equal(card);
+    expect(turn.currentCard).to.be.an.instanceof(Card);
+
+  });
+
+  it('should record the provided guess', function() {
+    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    const turn = new Turn('boo', card);
+
+    var turnGuessAnswer = turn.returnGuess();
+
+    expect(turnGuessAnswer).to.deep.equal(turn.guess);
+
+  });
+
+  it('should record the current card', function() {
+    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    const turn = new Turn('boo', card);
+
+    var turnCurrentCard = turn.returnCard();
+
+    expect(turnCurrentCard).to.deep.equal(turn.currentCard);
+  });
+
+  it('should evaluate our guessed answers', function() {
+    let card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    const turn = new Turn('boo', card);
+    const anotherTurn = new Turn('woo', card);
+
+    expect(turn.evaluateGuess()).to.equal(true);
+    expect(anotherTurn.evaluateGuess()).to.equal(false);
+  });
+
+  it('should give us a feedback', function() {
+    let card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    const turn = new Turn('boo', card);
+    const anotherTurn = new Turn('woo', card);
+
+    expect(turn.giveFeedback()).to.deep.equal('Correct!');
+    expect(anotherTurn.giveFeedback()).to.deep.equal('Incorrect!');
+  });
+});


### PR DESCRIPTION
## What is the change? 
Added test class and tests. 
Some adjustments are made in a card-test.js file

## What does it fix?
N/a

## Is this a fix or a feature? 
Feature/small fix

## Where should the reviewer start?
Turn.js:
line 1

Card-test.js:
line 20, 35, 40, 45, 55 - .deep is added for a strict equality 
line 28-32 - removed by accident question is returned 

Turn-test.js:
line 1

## How should this be tested?
The new turn tests should test the newly created turn class which takes two arguments: guess and a current card. The should be able to return the user guess, the current card, evaluate an answer, and give a feedback.