### PR TITLE
Add round/deck class/test and refactoring turn/card

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -5,13 +5,6 @@ class Card {
     this.answers = answers;
     this.correctAnswer = correctAnswer;
   }
-};
-
-
-
-
-
-
-
+}
 
 module.exports = Card;

--- a/src/Deck.js
+++ b/src/Deck.js
@@ -1,0 +1,11 @@
+class Deck {
+  constructor(cards) {
+    this.cards = cards || [];
+  }
+
+  countCards() {
+    return this.cards.length
+  }
+}
+
+module.exports = Deck;

--- a/src/Game.js
+++ b/src/Game.js
@@ -3,7 +3,9 @@ const prototypeQuestions = data.prototypeData;
 const util = require('./util');
 
 class Game {
-  constructor() {}
+  constructor(currentRound) {
+    this.currentRound = currentRound;
+  }
 
   printMessage(deck, round) {
       console.log(`Welcome to FlashCards! You are playing with ${deck.countCards()} cards.
@@ -12,6 +14,10 @@ class Game {
 
   printQuestion(round) {
       util.main(round);
+  }
+
+  start() {
+
   }
 }
 

--- a/src/Round.js
+++ b/src/Round.js
@@ -1,0 +1,41 @@
+const Turn = require('../src/Turn');
+
+class Round {
+  constructor(deck) {
+    deck = deck || {};
+    this.deck = deck.cards;
+    this.turn = 0;
+    this.incorrectGuesses = [];
+  }
+  returnCurrentCard() {
+    return this.deck.splice(0, 1)[0]
+  }
+
+  takeTurn(userGuess) {
+    let userTurn = new Turn(userGuess, this.returnCurrentCard());
+    this.turn += 1;
+    if (!userTurn.evaluateGuess()) {
+      this.incorrectGuesses.push(userTurn.currentCard.cardId);
+    }
+
+    return userTurn.giveFeedback();
+  }
+
+  calculatePercentCorrect() {
+    if (!this.turn) {
+      return "You didn't make any turns!";
+    } else {
+      let incorrectAnswersNum = this.incorrectGuesses.length;
+      let correctAnswersPercent = 100 - Math.round((incorrectAnswersNum / this.turn) * 100);
+      return correctAnswersPercent;
+    }
+  }
+
+  endRound() {
+    let correctPercent = this.calculatePercentCorrect();
+    return `** Round over! ** You answered ${correctPercent}% of the questions correctly!`;
+  }
+}
+
+
+module.exports = Round;

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -5,8 +5,14 @@ const Card = require('../src/Card');
 
 describe('Card', function() {
 
+  let card1, card2;
+
+  beforeEach (function() {
+    card1 = new Card(1, 'What is a scary word?', ['boo', 'bah', 'whah'], 'boo');
+    card2 = new Card(2, 'How many colors in a rainbow?', ['nine', 'many', 'seven'], 'seven');
+  });
+
   it('should be a function', function() {
-    const card = new Card();
     expect(Card).to.be.a('function');
   });
 
@@ -16,42 +22,31 @@ describe('Card', function() {
   });
 
   it('should store a question', function() {
-    const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-    expect(card.question).to.deep.equal('What allows you to define a set of related information using key-value pairs?');
+    expect(card1.question).to.deep.equal('What is a scary word?');
   });
 
   it('should store a list of possible answers', function() {
-    const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-    expect(card.answers).to.deep.equal(['object', 'array', 'function']);
+    expect(card1.answers).to.deep.equal(['boo', 'bah', 'whah']);
   });
 
   it('should store the correct answer', function() {
-    const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
-    expect(card.correctAnswer).to.deep.equal('object');
+    expect(card1.correctAnswer).to.deep.equal('boo');
   });
 
   it('should store a card ID', function() {
-    const card = new Card(1, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.cardId).to.deep.equal(1);
-  });
-
-  it('should store a different id', function() {
-    const card = new Card(2, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.cardId).to.deep.equal(2);
+    expect(card1.cardId).to.deep.equal(1);
+    expect(card2.cardId).to.deep.equal(2);
   });
 
   it('should store a different question', function() {
-    const card = new Card(2, 'What is a comma-separated list of related values?', ['object', 'array', 'function'], 'object');
-    expect(card.question).to.deep.equal('What is a comma-separated list of related values?');
+    expect(card2.question).to.deep.equal('How many colors in a rainbow?');
   });
 
   it('should store a different set of possible answers', function() {
-    const card = new Card(2, 'What is a comma-separated list of related values?', ["array", "object", "function"], 'object');
-    expect(card.answers).to.deep.equal(["array", "object", "function"]);
+    expect(card2.answers).to.deep.equal(['nine', 'many', 'seven']);
   });
 
   it('should store a different correct answer', function() {
-    const card = new Card(2, 'What is a comma-separated list of related values?', ["mutator method", "accessor method", "iteration method"], 'array');
-    expect(card.correctAnswer).to.deep.equal('array');
+    expect(card2.correctAnswer).to.deep.equal('seven');
   });
 });

--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -1,0 +1,55 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Deck = require('../src/Deck');
+const Card = require('../src/Card');
+
+describe('Card', function() {
+
+  it('should be a function', function() {
+    expect(Deck).to.be.a('function');
+  });
+
+  it('should be an instance of Deck', function() {
+    const deck = new Deck();
+    expect(deck).to.be.an.instanceof(Deck);
+  });
+
+  it('should have an empty deck as a default', function() {
+    const deck = new Deck();
+
+    expect(deck.cards).to.deep.equal([]);
+  });
+
+  it('should accept a card from a user', function() {
+    const card = new Card(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+    const deck = new Deck(card);
+
+    expect(deck.cards).to.equal(card);
+  });
+
+  it('should accept a list of multiple cards', function() {
+    const card1 = new Card(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+    const card2 = new Card(14, 'What organ is Khalid missing?', ['spleen', 'appendix', 'gallbladder'], 'gallbladder');
+    const card3 = new Card(12, 'What is Travis\'s middle name?', ['Lex', 'William', 'Fitzgerald'], 'Fitzgerald');
+    const firstDeck = new Deck();
+    const secondDeck = new Deck([card1, card2, card3]);
+
+    expect(firstDeck.cards).to.deep.equal([]);
+    expect(firstDeck.cards).to.be.an.instanceof(Array);
+
+    expect(secondDeck.cards).to.deep.equal([card1, card2, card3]);
+    expect(secondDeck.cards).to.be.an.instanceof(Array);
+  });
+
+  it('should accept a list of multiple cards', function() {
+    const card1 = new Card(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+    const card2 = new Card(14, 'What organ is Khalid missing?', ['spleen', 'appendix', 'gallbladder'], 'gallbladder');
+    const card3 = new Card(12, 'What is Travis\'s middle name?', ['Lex', 'William', 'Fitzgerald'], 'Fitzgerald');
+    const firstDeck = new Deck([card1, card2, card3]);
+    const secondDeck = new Deck([]);
+
+    expect(firstDeck.countCards()).to.equal(3);
+    expect(secondDeck.countCards()).to.equal(0);
+  });
+});

--- a/test/Round-test.js
+++ b/test/Round-test.js
@@ -1,0 +1,96 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Round = require('../src/Round');
+const Deck = require('../src/Deck');
+const Card = require('../src/Card');
+
+describe('Round', function() {
+  let card1, card2, card3, deck, round;
+
+  beforeEach (function() {
+    card1 = new Card(1, 'What is a scary word?', ['boo', 'bah', 'whah'], 'boo');
+    card2 = new Card(2, 'How many colors in a rainbow?', ['nine', 'many', 'seven'], 'seven');
+    card3 = new Card(3, 'Is Pluto a planet?', ['pluto is always a planet to me', 'no', 'I do not know'], 'no');
+    deck = new Deck([card1, card2, card3]);
+    round = new Round(deck);
+  });
+
+  it('should be a function', function() {
+
+    expect(Round).to.be.a('function');
+  });
+
+  it('should be an instance of Round', function() {
+
+    const round = new Round();
+    expect(round).to.be.an.instanceof(Round);
+  });
+
+  it('should have a deck of cards', function() {
+
+    expect(round.deck).to.deep.equal([card1, card2, card3]);
+    expect(deck).to.be.an.instanceof(Deck);
+  });
+
+  it('should be able to take the top card from the deck', function() {
+
+    expect(round.deck).to.deep.equal([card1, card2, card3]);
+
+    var getCurrentCard = round.returnCurrentCard();
+
+    expect(getCurrentCard).to.deep.equal(card1);
+    expect(round.deck).to.deep.equal([card2, card3]);
+  });
+
+  it('should take a turn when guess is made', function() {
+
+    expect(round.turn).to.deep.equal(0);
+
+    round.takeTurn('boo');
+    expect(round.turn).to.deep.equal(1);
+
+    round.takeTurn('woo');
+    expect(round.turn).to.deep.equal(2);
+  });
+
+  it('should give a feedback to a user if the answer is correct or not', function() {
+
+    expect(round.takeTurn('boo')).to.deep.equal('Correct!');
+    expect(round.takeTurn('woo')).to.deep.equal('Incorrect!');
+  });
+
+  it('should record incorrect answers in an array storing the card id', function() {
+
+    expect(round.incorrectGuesses.length).to.equal(0);
+
+    expect(round.takeTurn('woo')).to.deep.equal('Incorrect!');
+    expect(round.takeTurn('many')).to.deep.equal('Incorrect!');
+    expect(round.takeTurn('no')).to.deep.equal('Correct!');
+
+    expect(round.incorrectGuesses.length).to.equal(2);
+    expect(round.incorrectGuesses).to.deep.equal([1, 2]);
+  });
+
+  it('should calculate percent of the correct answers', function() {
+
+    expect(round.turn).to.deep.equal(0);
+    expect(round.calculatePercentCorrect()).to.equal("You didn't make any turns!");
+
+    round.takeTurn('boo');
+    expect(round.turn).to.deep.equal(1);
+    expect(round.incorrectGuesses.length).to.equal(0);
+
+    round.takeTurn('many');
+    expect(round.turn).to.deep.equal(2);
+    expect(round.incorrectGuesses.length).to.equal(1);
+
+    expect(round.calculatePercentCorrect()).to.equal(50);
+
+    round.takeTurn('pluto is always a planet to me');
+    expect(round.turn).to.deep.equal(3);
+    expect(round.incorrectGuesses.length).to.equal(2);
+
+    expect(round.calculatePercentCorrect()).to.equal(33);
+  });
+});

--- a/test/Turn-test.js
+++ b/test/Turn-test.js
@@ -6,70 +6,57 @@ const Card = require('../src/Card');
 
 describe('Turn', function() {
 
+  let card1, card2, turn, anotherTurn;
+
+  beforeEach (function() {
+    card1 = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
+    card2 = new Card(2, 'How many colors in a rainbow?', ['nine', 'many', 'seven'], 'seven');
+    turn = new Turn('boo', card1);
+    anotherTurn = new Turn('woo', card2);
+  });
+
   it('should be a function', function() {
-    const turn = new Turn();
     expect(Turn).to.be.a('function');
   });
 
   it('should be an instance of Turn', function() {
-    const turn = new Turn();
     expect(turn).to.be.an.instanceof(Turn);
   });
 
   it('should only accept a string answer from a user', function() {
-    const turn = new Turn('boo');
-    const newTurn = new Turn('woo');
-
     expect(turn.guess).to.equal('boo');
-    expect(turn.guess).to.be.a.string('boo');
+    expect(turn.guess).to.be.a('string');
 
-    expect(newTurn.guess).to.equal('woo');
-    expect(newTurn.guess).to.be.a.string('woo');
+    expect(anotherTurn.guess).to.equal('woo');
+    expect(anotherTurn.guess).to.be.a('string');
   });
 
   it('should play the current card', function() {
-    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
-    const turn = new Turn('boo', card);
-
-    expect(turn.currentCard).to.deep.equal(card);
+    expect(turn.currentCard).to.equal(card1);
     expect(turn.currentCard).to.be.an.instanceof(Card);
 
   });
 
   it('should record the provided guess', function() {
-    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
-    const turn = new Turn('boo', card);
-
     var turnGuessAnswer = turn.returnGuess();
 
-    expect(turnGuessAnswer).to.deep.equal(turn.guess);
+    expect(turnGuessAnswer).to.equal(turn.guess);
 
   });
 
   it('should record the current card', function() {
-    const card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
-    const turn = new Turn('boo', card);
-
     var turnCurrentCard = turn.returnCard();
 
-    expect(turnCurrentCard).to.deep.equal(turn.currentCard);
+    expect(turnCurrentCard).to.equal(turn.currentCard);
   });
 
   it('should evaluate our guessed answers', function() {
-    let card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
-    const turn = new Turn('boo', card);
-    const anotherTurn = new Turn('woo', card);
-
     expect(turn.evaluateGuess()).to.equal(true);
     expect(anotherTurn.evaluateGuess()).to.equal(false);
   });
 
   it('should give us a feedback', function() {
-    let card = new Card(1, "What is a scary word?", ['boo', 'bah', 'whah'], 'boo');
-    const turn = new Turn('boo', card);
-    const anotherTurn = new Turn('woo', card);
-
-    expect(turn.giveFeedback()).to.deep.equal('Correct!');
-    expect(anotherTurn.giveFeedback()).to.deep.equal('Incorrect!');
+    expect(turn.giveFeedback()).to.equal('Correct!');
+    expect(anotherTurn.giveFeedback()).to.equal('Incorrect!');
   });
 });


### PR DESCRIPTION
## What is the change? 
New classes and tests were created: Round and Deck. Card and Turn classes were refactored and adjusted.

## What does it fix?
Readability, applying DRY and SRP rules 

## Is this a fix or a feature?  
feature/small fixes

## Where should the reviewer start? 
Round.js/Round-test.js:
line 1
Deck.js/Deck-test.js:
line 1

Card-test.js:
line 8-14 - beforeEach is added
line 18-55 - repetitive class instances declarations were removed

Card.js:
whitespace removed before module.exports

Turn-test.js:
line 9-17 - beforeEach is added
line 10-73 - repetitive class instances declarations were removed, naming of card was changed to card1 for the consistency. 

## How should this be tested?
New Deck class is able to create a deck of cards and counts its amount.
New Round class should be able to create a new Turn instance, count the turns, provide feedback to the user, record incorrect answers and calculate the percent of correct guesses.

